### PR TITLE
add policy for workspace-ui

### DIFF
--- a/policies/eoepca/workspace/wsui.rego
+++ b/policies/eoepca/workspace/wsui.rego
@@ -1,0 +1,19 @@
+package eoepca.workspace.wsapi
+
+import rego.v1
+import input.request
+import data.eoepca.iam.util.verified_claims
+
+default allow = false
+
+allow if {
+    claims := verified_claims
+    claims != null
+
+    url := request.url
+    host_parts := split(url, "/")
+    domain := host_parts[2]
+    ws_parts := split(domain, ".")
+    wsName := ws_parts[0]
+    "ws_access" in claims.resource_access[wsName].roles
+}

--- a/policies/eoepca/workspace/wsui.rego
+++ b/policies/eoepca/workspace/wsui.rego
@@ -1,4 +1,4 @@
-package eoepca.workspace.wsapi
+package eoepca.workspace.wsui
 
 import rego.v1
 import input.request


### PR DESCRIPTION
Workspace-UI will be deployed at urls like https://ws-example-78.apx.develop.eoepca.org/

we will follow same logic as for Workspace-API, i.e. user must be in (through workspace-pipeline component) automatically created group ws-example-78 (which has role mapping for ws_access in client ws-example-78)